### PR TITLE
Pickle fixes, and other changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,21 +3,21 @@ from sanic import Sanic, response
 from sanic_testing import TestManager
 
 
+def _basic_response(request):
+    return response.text("foo")
+
 @pytest.fixture
 def app():
     sanic_app = Sanic(__name__)
     TestManager(sanic_app)
 
-    @sanic_app.route(
+    sanic_app.route(
         "/", methods=["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"]
-    )
-    def basic(request):
-        return response.text("foo")
-
+    )(_basic_response)
     return sanic_app
-
 
 @pytest.fixture
 def manager():
     sanic_app = Sanic(__name__)
     return TestManager(sanic_app)
+

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,5 @@
+import pytest
+import pickle
 from sanic import Sanic
 from sanic_testing import TestManager
 from sanic_testing.testing import SanicASGITestClient, SanicTestClient
@@ -12,3 +14,16 @@ def test_manager_initialization(manager):
     assert isinstance(manager.test_client, SanicTestClient)
     assert isinstance(manager.asgi_client, SanicASGITestClient)
     assert isinstance(manager, TestManager)
+
+@pytest.mark.parametrize("protocol", [3, 4])
+def test_pickle_app(protocol):
+    app = Sanic("test_pickle_app")
+    manager = TestManager(app)
+    assert app._test_manager == manager
+    my_dict = {"app": app}
+    my_pickled = pickle.dumps(my_dict, protocol=protocol)
+    del my_dict
+    del app
+    del manager
+    my_new_dict = pickle.loads(my_pickled)
+    assert my_new_dict["app"]._test_manager


### PR DESCRIPTION
Sorry about bundling these all up, while fixing #3 I found some issues and fixed them all in one go.

* Move nested subfuctions out of TestClient class methods. This fixes a weird App pickling error seen when using TestManager (specifically on the ASGITestClient)

* Add logic to remove the CookieJar from ASGITestClient before pickling, then add it back when unpickled. The cookie jar contains a ThreadLock which cannot be pickled.

* Fixes #3

* Improve gather_request logic in TestClient and ASGITestClient, Fixes #4

* Change "before_server_end" to "before_server_stop". Fixes #5

* Fix return type on _sanic_endpoint_test, Fixes #6

* Re-Blacked all python files