### PR TITLE
Move Sanic requirement to master branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+pretty:
+	black --line-length 79 sanic_testing tests
+	isort --line-length 79 sanic_testing tests

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -1,4 +1,3 @@
-#-e git+git@github.com:huge-success/sanic.git@c85f99254ff5ef80a4eceefd4ed3a5b09b68d7ab#egg=sanic
-sanic
+git+git://github.com/sanic-org/sanic.git@master#egg=sanic
 pytest
 pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+black
+isort

--- a/sanic_testing/__init__.py
+++ b/sanic_testing/__init__.py
@@ -1,4 +1,4 @@
 from sanic_testing.manager import TestManager
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = ("TestManager",)

--- a/sanic_testing/manager.py
+++ b/sanic_testing/manager.py
@@ -1,4 +1,4 @@
-from sanic import Sanic
+from sanic import Sanic  # type: ignore
 
 from sanic_testing.testing import SanicASGITestClient, SanicTestClient
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 import pytest
 from sanic import Sanic, response
+
 from sanic_testing import TestManager
 
 
 def _basic_response(request):
     return response.text("foo")
+
 
 @pytest.fixture
 def app():
@@ -16,8 +18,8 @@ def app():
     )(_basic_response)
     return sanic_app
 
+
 @pytest.fixture
 def manager():
     sanic_app = Sanic(__name__)
     return TestManager(sanic_app)
-

--- a/tests/test_asgi_client.py
+++ b/tests/test_asgi_client.py
@@ -1,13 +1,12 @@
 import asyncio
 
 import pytest
-
 from sanic.request import Request
 
 
 @pytest.mark.asyncio
 async def test_basic_asgi_client(app):
-    for method in ['get', "post", "patch", "put", "delete", "options"]:
+    for method in ["get", "post", "patch", "put", "delete", "options"]:
         request, response = await getattr(app.asgi_client, method)("/")
 
         assert isinstance(request, Request)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,8 @@
-import pytest
 import pickle
+
+import pytest
 from sanic import Sanic
+
 from sanic_testing import TestManager
 from sanic_testing.testing import SanicASGITestClient, SanicTestClient
 
@@ -14,6 +16,7 @@ def test_manager_initialization(manager):
     assert isinstance(manager.test_client, SanicTestClient)
     assert isinstance(manager.asgi_client, SanicASGITestClient)
     assert isinstance(manager, TestManager)
+
 
 @pytest.mark.parametrize("protocol", [3, 4])
 def test_pickle_app(protocol):

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,8 @@ deps =
 
 commands =
     flake8 sanic_testing
-    black --check --verbose sanic_testing
-    isort --check --recursive sanic_testing
+    black --check --line-length 79 sanic_testing tests
+	isort --check --line-length 79 sanic_testing tests
     mypy sanic_testing
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,12 @@
 [tox]
-envlist = py36, py37, py38, lint
+envlist = py36, py37, py38, py39, check
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38, check
+    3.9: py39
 
 [testenv]
 deps =
@@ -7,16 +14,19 @@ deps =
 commands =
     pytest {posargs:tests tests sanic_testing}
 
-[testenv:lint]
+[testenv:check]
 deps =
     flake8
     black
     isort
+    mypy
 
 commands =
     flake8 sanic_testing
     black --check --verbose sanic_testing
-    isort --check-only --recursive sanic_testing
+    isort --check --recursive sanic_testing
+    mypy sanic_testing
+
 
 [pytest]
 filterwarnings =


### PR DESCRIPTION
It does not make sense to have the test suite run against the PyPI version of Sanic (currently). Therefore, this change will make the `tox` suite use Sanic master branch from GH.

_After_ the 21.3 release, we should update so there are two requirements files. One with PyPI and one with the master branch. Then we can have two sets of tox envs to test both against the released and unreleased versions of Sanic.