### PR TITLE
Return tuples

### DIFF
--- a/tests/test_asgi_client.py
+++ b/tests/test_asgi_client.py
@@ -5,14 +5,16 @@ from sanic.request import Request
 
 
 @pytest.mark.asyncio
-async def test_basic_asgi_client(app):
-    for method in ["get", "post", "patch", "put", "delete", "options"]:
-        request, response = await getattr(app.asgi_client, method)("/")
+@pytest.mark.parametrize(
+    "method", ["get", "post", "patch", "put", "delete", "options"]
+)
+async def test_basic_asgi_client(app, method):
+    request, response = await getattr(app.asgi_client, method)("/")
 
-        assert isinstance(request, Request)
-        assert response.body == b"foo"
-        assert response.status == 200
-        assert response.content_type == "text/plain; charset=utf-8"
+    assert isinstance(request, Request)
+    assert response.body == b"foo"
+    assert response.status == 200
+    assert response.content_type == "text/plain; charset=utf-8"
 
 
 @pytest.mark.asyncio

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -1,10 +1,14 @@
 import asyncio
 
+import pytest
 from sanic.request import Request
 
 
-def test_basic_test_client(app):
-    request, response = app.test_client.get("/")
+@pytest.mark.parametrize(
+    "method", ["get", "post", "patch", "put", "delete", "options"]
+)
+def test_basic_test_client(app, method):
+    request, response = getattr(app.test_client, method)("/")
 
     assert isinstance(request, Request)
     assert response.body == b"foo"


### PR DESCRIPTION
Fix #10, always return a tuple from SanicTestClient request, and ASGITestClient `request()`