### PR TITLE
prevent PytestCollectionWarning for TestManager

### DIFF
--- a/sanic_testing/manager.py
+++ b/sanic_testing/manager.py
@@ -4,6 +4,8 @@ from sanic_testing.testing import SanicASGITestClient, SanicTestClient
 
 
 class TestManager:
+    __test__ = False
+    
     def __init__(self, app: Sanic) -> None:
         self.test_client = SanicTestClient(app)
         self.asgi_client = SanicASGITestClient(app)

--- a/sanic_testing/manager.py
+++ b/sanic_testing/manager.py
@@ -5,7 +5,7 @@ from sanic_testing.testing import SanicASGITestClient, SanicTestClient
 
 class TestManager:
     __test__ = False
-    
+
     def __init__(self, app: Sanic) -> None:
         self.test_client = SanicTestClient(app)
         self.asgi_client = SanicASGITestClient(app)


### PR DESCRIPTION
As explained in this [blog post](https://adamj.eu/tech/2020/07/28/how-to-fix-a-pytest-collection-warning-about-web-tests-test-app-class/), pytest will attempt to collect `TestManager` (since it matches `Test*`) and raise a warning unless `__test__` property is set to `False`.