### PR TITLE
Add reusable client

### DIFF
--- a/sanic_testing/__init__.py
+++ b/sanic_testing/__init__.py
@@ -1,4 +1,4 @@
 from sanic_testing.manager import TestManager
 
-__version__ = "0.6.0"
+__version__ = "0.7.0b1"
 __all__ = ("TestManager",)

--- a/sanic_testing/reusable.py
+++ b/sanic_testing/reusable.py
@@ -8,7 +8,7 @@ from sanic import Sanic
 from sanic.log import logger
 from sanic.request import Request
 from sanic.server import trigger_events
-from websockets import connect
+from websockets.legacy.client import connect
 
 from .testing import HOST, PORT, TestingResponse
 

--- a/sanic_testing/reusable.py
+++ b/sanic_testing/reusable.py
@@ -1,0 +1,212 @@
+import asyncio
+from functools import partial
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+from sanic import Sanic
+from sanic.log import logger
+from sanic.request import Request
+from sanic.server import trigger_events
+from websockets import connect
+
+from .testing import HOST, PORT, TestingResponse
+
+
+class ReusableClient:
+    def __init__(
+        self,
+        app: Sanic,
+        host=HOST,
+        port=PORT,
+        loop=None,
+        server_kwargs=None,
+        client_kwargs=None,
+    ):
+        if not loop:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        server_kwargs = server_kwargs or {}
+        client_kwargs = client_kwargs or {}
+
+        app.test_mode = True
+        self.app = app
+        self.host = host
+        self.port = port
+        self._loop = loop
+        self.debug = False
+        self._server = None
+
+        self._session = httpx.AsyncClient(verify=False, **client_kwargs)
+        self._server_co = self.app.create_server(
+            host=self.host,
+            debug=self.debug,
+            port=self.port,
+            return_asyncio_server=True,
+            **server_kwargs,
+        )
+
+    def __enter__(self):
+        self.run()
+
+    def __exit__(self, *_):
+        self.stop()
+
+    def run(self):
+        self._loop._stopping = False
+        self.app.router.reset()
+        self.app.signal_router.reset()
+        self._run(Sanic.finalize(self.app, None))
+        trigger_events(self.app.listeners["before_server_start"], self._loop)
+        self._server = self._run(self._server_co)
+        trigger_events(self.app.listeners["after_server_start"], self._loop)
+
+    def stop(self):
+        if self._server:
+            self._server.close()
+            self._run(self._server.wait_closed())
+            self._server = None
+
+        if self._session:
+            self._run(self._session.aclose())
+            self._session = None
+
+    def _sanic_endpoint_test(
+        self,
+        method: str = "get",
+        uri: str = "/",
+        gather_request: bool = True,
+        debug: bool = False,
+        server_kwargs: Optional[Dict[str, Any]] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        allow_none: bool = False,
+        *request_args,
+        **request_kwargs,
+    ) -> Tuple[Optional[Request], Optional[TestingResponse]]:
+        request_data: Dict[str, Request] = {}
+        exceptions: List[Exception] = []
+
+        host = host or self.host
+        port = port or self.port
+
+        if gather_request:
+            _collect_request = partial(self._collect_request, request_data)
+            self.app.request_middleware.appendleft(  # type: ignore
+                _collect_request
+            )
+
+        if uri.startswith(
+            ("http:", "https:", "ftp:", "ftps://", "//", "ws:", "wss:")
+        ):
+            url = uri
+        else:
+            uri = uri if uri.startswith("/") else f"/{uri}"
+            scheme = "ws" if method == "websocket" else "http"
+            url = f"{scheme}://{host}:{port}{uri}"
+
+        if exceptions:
+            raise ValueError(f"Exception during request: {exceptions}")
+
+        response = self._run(
+            self._local_request(method, url, *request_args, **request_kwargs)
+        )
+
+        try:
+            self.app.request_middleware.remove(  # type: ignore
+                _collect_request
+            )
+        except BaseException:  # noqa
+            pass
+
+        try:
+            request = request_data.get("request") if gather_request else None
+            if response is None:
+                if not allow_none:
+                    raise ValueError(
+                        "No response returned to Sanic Test Client."
+                    )
+            return request, response
+        except BaseException:  # noqa
+            if not allow_none:
+                raise ValueError(
+                    "Request and response object expected, "
+                    f"got ({request}, {response})"
+                )
+
+        return None, None
+
+    async def _local_request(self, method, url, *args, **kwargs):
+        raw_cookies = kwargs.pop("raw_cookies", None)
+
+        if method == "websocket":
+            ws_proxy = SimpleNamespace()
+            async with connect(url, *args, **kwargs) as websocket:
+                ws_proxy.ws = websocket
+                ws_proxy.opened = True
+            return ws_proxy
+        else:
+            session = self._session
+
+            try:
+                if method == "request":
+                    args = tuple([url] + list(args))
+                    url = kwargs.pop("http_method", "GET").upper()
+                response = await getattr(session, method.lower())(
+                    url, *args, **kwargs
+                )
+            except httpx.HTTPError as e:
+                if hasattr(e, "response"):
+                    response = getattr(e, "response")
+                else:
+                    logger.error(
+                        f"{method.upper()} {url} received no response!",
+                        exc_info=True,
+                    )
+                    return None
+
+            response.__class__ = TestingResponse
+
+            if raw_cookies:
+                response.raw_cookies = {}
+
+                for cookie in response.cookies.jar:
+                    response.raw_cookies[cookie.name] = cookie
+
+            return response
+
+    def _run(self, coro):
+        if not self._loop:
+            raise RuntimeError("Test client has no loop")
+        return self._loop.run_until_complete(coro)
+
+    @staticmethod
+    def _collect_request(data, request):
+        data["request"] = request
+
+    def request(self, *args, **kwargs):
+        return self._sanic_endpoint_test("request", *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self._sanic_endpoint_test("get", *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        return self._sanic_endpoint_test("post", *args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        return self._sanic_endpoint_test("put", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        return self._sanic_endpoint_test("delete", *args, **kwargs)
+
+    def patch(self, *args, **kwargs):
+        return self._sanic_endpoint_test("patch", *args, **kwargs)
+
+    def options(self, *args, **kwargs):
+        return self._sanic_endpoint_test("options", *args, **kwargs)
+
+    def head(self, *args, **kwargs):
+        return self._sanic_endpoint_test("head", *args, **kwargs)
+
+    def websocket(self, *args, **kwargs):
+        return self._sanic_endpoint_test("websocket", *args, **kwargs)

--- a/sanic_testing/testing.py
+++ b/sanic_testing/testing.py
@@ -12,7 +12,7 @@ from sanic.exceptions import MethodNotSupported  # type: ignore
 from sanic.log import logger  # type: ignore
 from sanic.request import Request  # type: ignore
 from sanic.response import text  # type: ignore
-from websockets import connect
+from websockets.legacy.client import connect
 
 ASGI_HOST = "mockserver"
 ASGI_PORT = 1234

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     black
     isort
     mypy
+    sanic
 
 commands =
     flake8 sanic_testing

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ python =
 deps =
     -r{toxinidir}/requirements.testing.txt
 commands =
-    pytest {posargs:tests tests sanic_testing}
+    pytest {posargs:tests sanic_testing}
 
 [testenv:check]
 deps =


### PR DESCRIPTION
One of the things that is missing is a clean interface for opening a single server and running multiple requests against it instead of standing up a single use server for every request.

This is the beginning of that interface, which will be released as a pre-release version. The implementation will likely change some before final release to coincide with the 21.9 Sanic release.