### PR TITLE
Add functionality to mimic a websocket client against an endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ build/*
 .DS_Store
 dist/*
 pip-wheel-metadata/
+.venv
+.vscode

--- a/sanic_testing/testing.py
+++ b/sanic_testing/testing.py
@@ -4,7 +4,6 @@ from ipaddress import IPv6Address, ip_address
 from json import JSONDecodeError
 from socket import AF_INET6, SOCK_STREAM, socket
 from string import ascii_lowercase
-from types import SimpleNamespace
 
 import httpx
 from sanic import Sanic  # type: ignore
@@ -13,8 +12,8 @@ from sanic.exceptions import MethodNotSupported  # type: ignore
 from sanic.log import logger  # type: ignore
 from sanic.request import Request  # type: ignore
 from sanic.response import text  # type: ignore
-from websockets.exceptions import ConnectionClosedOK
-from websockets.legacy.client import connect
+
+from sanic_testing.websocket import websocket_proxy
 
 ASGI_HOST = "mockserver"
 ASGI_PORT = 1234
@@ -95,34 +94,7 @@ class SanicTestClient:
                 kwargs["follow_redirects"] = allow_redirects
 
         if method == "websocket":
-            ws_proxy = SimpleNamespace()
-            mimic = kwargs.pop("mimic", None)
-            async with connect(url, *args, **kwargs) as websocket:
-                ws_proxy.ws = websocket
-                ws_proxy.opened = True
-                ws_proxy.received = []
-                ws_proxy.sent = []
-
-                if mimic:
-                    do_send = websocket.send
-                    do_recv = websocket.recv
-
-                    async def send(data):
-                        ws_proxy.received.append(data)
-                        await do_send(data)
-
-                    async def recv():
-                        message = await do_recv()
-                        ws_proxy.sent.append(message)
-
-                    websocket.send = send  # type: ignore
-                    websocket.recv = recv  # type: ignore
-
-                    try:
-                        await mimic(websocket)
-                    except ConnectionClosedOK:
-                        pass
-            return ws_proxy
+            return await websocket_proxy(url, *args, **kwargs)
         else:
             async with self.get_new_session(**session_kwargs) as session:
 
@@ -329,7 +301,15 @@ class SanicTestClient:
     def head(self, *args, **kwargs):
         return self._sanic_endpoint_test("head", *args, **kwargs)
 
-    def websocket(self, *args, **kwargs):
+    def websocket(
+        self,
+        *args,
+        mimic: typing.Optional[
+            typing.Callable[..., typing.Coroutine[None, None, typing.Any]]
+        ] = None,
+        **kwargs,
+    ):
+        kwargs["mimic"] = mimic
         return self._sanic_endpoint_test("websocket", *args, **kwargs)
 
 
@@ -421,7 +401,21 @@ class SanicASGITestClient(httpx.AsyncClient):
     async def _ws_send(cls, message):
         pass
 
-    async def websocket(self, uri, subprotocols=None, *args, **kwargs):
+    async def websocket(
+        self,
+        uri,
+        subprotocols=None,
+        *args,
+        mimic: typing.Optional[
+            typing.Callable[..., typing.Coroutine[None, None, typing.Any]]
+        ] = None,
+        **kwargs,
+    ):
+        if mimic:
+            raise RuntimeError(
+                "SanicASGITestClient does not currently support the mimic "
+                "keyword argument. Please use SanicTestClient instead."
+            )
         scheme = "ws"
         path = uri
         root_path = f"{scheme}://{ASGI_HOST}:{ASGI_PORT}"

--- a/sanic_testing/testing.py
+++ b/sanic_testing/testing.py
@@ -1,5 +1,4 @@
 import typing
-from asyncio import sleep
 from functools import partial
 from ipaddress import IPv6Address, ip_address
 from json import JSONDecodeError
@@ -119,18 +118,10 @@ class SanicTestClient:
                     websocket.send = send  # type: ignore
                     websocket.recv = recv  # type: ignore
 
-                    async def do_mimic():
-                        try:
-                            await mimic(websocket)
-                        except ConnectionClosedOK:
-                            ...
-                        else:
-                            await websocket.send("")
-
-                    task = self.app.loop.create_task(do_mimic())
-
-                    while not task.done():
-                        await sleep(0.1)
+                    try:
+                        await mimic(websocket)
+                    except ConnectionClosedOK:
+                        pass
             return ws_proxy
         else:
             async with self.get_new_session(**session_kwargs) as session:

--- a/sanic_testing/websocket.py
+++ b/sanic_testing/websocket.py
@@ -1,0 +1,49 @@
+import typing
+
+from websockets.exceptions import ConnectionClosedOK
+from websockets.legacy.client import connect
+
+
+class WebsocketProxy:
+    def __init__(self, ws):
+        self.ws = ws
+        self.opened = True
+        self.client_received: typing.List[str] = []
+        self.client_sent: typing.List[str] = []
+
+    @property
+    def server_received(self):
+        return self.client_sent
+
+    @property
+    def server_sent(self):
+        return self.client_received
+
+
+async def websocket_proxy(url, *args, **kwargs) -> WebsocketProxy:
+    mimic = kwargs.pop("mimic", None)
+    async with connect(url, *args, **kwargs) as websocket:
+        ws_proxy = WebsocketProxy(websocket)
+
+        if mimic:
+            do_send = websocket.send
+            do_recv = websocket.recv
+
+            async def send(data):
+                ws_proxy.client_sent.append(data)
+                await do_send(data)
+
+            async def recv():
+                message = await do_recv()
+                ws_proxy.client_received.append(message)
+
+            websocket.send = send  # type: ignore
+            websocket.recv = recv  # type: ignore
+
+            try:
+                await mimic(websocket)
+            except ConnectionClosedOK:
+                pass
+            else:
+                await websocket.send("")
+    return ws_proxy

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -45,8 +45,8 @@ def test_websocket_route_queue(app: Sanic):
                 break
 
     _, response = app.test_client.websocket("/ws", mimic=client_mimic)
-    assert response.sent == ["hello!"]
-    assert response.received == ["foo"]
+    assert response.server_sent == ["hello!"]
+    assert response.server_received == ["foo", ""]
 
 
 def test_websocket_client_mimic_failed(app: Sanic):
@@ -58,7 +58,7 @@ def test_websocket_client_mimic_failed(app: Sanic):
         raise Exception("Should fails")
 
     with pytest.raises(Exception, match="Should fails"):
-        _, response = app.test_client.websocket("/ws", mimic=client_mimic)
+        app.test_client.websocket("/ws", mimic=client_mimic)
 
 
 def test_listeners(app):


### PR DESCRIPTION
This PR is meant to introduce a new API to test websocket endpoints. To do this, the developer would pass an async function that can `send` and `recv` messages from the endpoint. To test, these values will be stored and accessible to `assert` against.

```python
def test_websocket_route_queue(app: Sanic):
    async def client_mimic(websocket: WebSocketClientProtocol):
        await websocket.send("foo")
        await websocket.recv()

    @app.websocket("/ws")
    async def handler(request, ws: Websocket):
        while True:
            await ws.send("hello!")
            if not await ws.recv():
                break

    _, response = app.test_client.websocket("/ws", mimic=client_mimic)
    assert response.server_sent == ["hello!"]
    assert response.server_received == ["foo", ""]
```