### PR TITLE
Add `raw_path` to ASGI scope of test client.

### DIFF
--- a/sanic_testing/testing.py
+++ b/sanic_testing/testing.py
@@ -446,6 +446,7 @@ class SanicASGITestClient(httpx.AsyncClient):
             "scheme": scheme,
             "root_path": root_path,
             "path": path,
+            "raw_path": path.encode(),
             "query_string": b"",
             "subprotocols": subprotocols,
         }


### PR DESCRIPTION
The unquoted `path` property is problematic, thus ASGI and all clients (it would seem) added a `raw_path` property that does not decode or unquote the path.
