### PR TITLE
Add reusable client tests and refactor

### DIFF
--- a/sanic_testing/reusable.py
+++ b/sanic_testing/reusable.py
@@ -81,14 +81,15 @@ class ReusableClient:
         self._run(
             self.app._server_event("shutdown", "before", loop=self._loop)
         )
+        if self._session:
+            self._run(self._session.aclose())
+            self._session = None
+
         if self._server:
             self._server.close()
             self._run(self._server.wait_closed())
             self._server = None
 
-        if self._session:
-            self._run(self._session.aclose())
-            self._session = None
         self._run(self.app._server_event("shutdown", "after", loop=self._loop))
 
     def _sanic_endpoint_test(

--- a/tests/test_reusable_client.py
+++ b/tests/test_reusable_client.py
@@ -1,0 +1,26 @@
+import pytest
+from sanic import Sanic, response
+
+from sanic_testing.reusable import ReusableClient
+
+
+@pytest.fixture
+def reusable_app():
+    sanic_app = Sanic(__name__)
+
+    @sanic_app.get("/")
+    def basic(request):
+        return response.text("foo")
+
+    return sanic_app
+
+
+@pytest.mark.asyncio
+def test_basic_asgi_client(reusable_app):
+    client = ReusableClient(reusable_app)
+    with client:
+        request, response = client.get("/")
+
+        assert request.method.lower() == "get"
+        assert response.body == b"foo"
+        assert response.status == 200


### PR DESCRIPTION
In Python 3.12, its required to close the writer to stop the server. unless its hangs on `wait_closed`

how to reproduce:
python=3.12.x
```python
import pytest
from sanic import Sanic, response

from sanic_testing.reusable import ReusableClient


@pytest.fixture
def reusable_app():
    sanic_app = Sanic(__name__)

    @sanic_app.get("/")
    def basic(request):
        return response.text("foo")

    return sanic_app


@pytest.mark.asyncio
def test_basic_asgi_client(reusable_app):
    client = ReusableClient(reusable_app)
    with client:
        request, response = client.get("/")

        assert request.method.lower() == "get"
        assert response.body == b"foo"
        assert response.status == 200
```