### PR TITLE
Update websockets to v14.0

### DIFF
--- a/sanic_testing/websocket.py
+++ b/sanic_testing/websocket.py
@@ -1,7 +1,7 @@
 import typing
 
 from websockets.exceptions import ConnectionClosedOK
-from websockets.legacy.client import connect
+from websockets.asyncio.client import connect
 
 
 class WebsocketProxy:

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 from sanic import Sanic, Websocket
 from sanic.request import Request
-from websockets.client import WebSocketClientProtocol
+from websockets.asyncio.client import ClientConnection
 
 
 @pytest.mark.parametrize(
@@ -33,7 +33,7 @@ def test_websocket_route_basic(app):
 
 
 def test_websocket_route_queue(app: Sanic):
-    async def client_mimic(websocket: WebSocketClientProtocol):
+    async def client_mimic(websocket: ClientConnection):
         await websocket.send("foo")
         await websocket.recv()
 
@@ -54,7 +54,7 @@ def test_websocket_client_mimic_failed(app: Sanic):
     async def handler(request, ws: Websocket):
         pass
 
-    async def client_mimic(websocket: WebSocketClientProtocol):
+    async def client_mimic(websocket: ClientConnection):
         raise Exception("Should fails")
 
     with pytest.raises(Exception, match="Should fails"):


### PR DESCRIPTION
Fixes #77

Updates the `websockets` dependency to v14.0, since `websockets.legacy` is deprecated.